### PR TITLE
[Fix] roundTripTranslation method exception

### DIFF
--- a/utils/PapagoKoRTT.py
+++ b/utils/PapagoKoRTT.py
@@ -47,7 +47,13 @@ class PapagoKoRTT:
             print('ERROR backTranslation', '\n', 'ERROR IS :::::::', e)
 
     def roundTripTranslation(self):
-        self.translation(self.sentence)
-        output = self.backTranslation()
+        try:
+            self.translation(self.sentence)
+            output = self.backTranslation()
 
-        return output
+            return output
+        except Exception as e:
+            print('='*30)
+            print('ERROR backTranslation', '\n', 'ERROR IS :::::::', e)
+
+            return self.sentence


### PR DESCRIPTION
## [Fix] roundTripTranslation method exception
- `roundTripTranslation` 함수 실행시, `error` 가 발생하면 `RTT` 없이 기존의 `input sentence`를 `return` 합니다. 